### PR TITLE
Reduce desktop homepage hero height

### DIFF
--- a/styles/layout.css
+++ b/styles/layout.css
@@ -41,6 +41,20 @@ h2 {
   line-height: 1.65;
 }
 
+@media (min-width: 900px) {
+  .hero {
+    padding: clamp(42px, 6vw, 68px) 0 12px;
+  }
+
+  .hero h1 {
+    font-size: clamp(3.25rem, 5.6vw, 4.9rem);
+  }
+
+  .hero-copy {
+    margin: 14px 0 18px;
+  }
+}
+
 .search-form {
   position: relative;
   display: flex;


### PR DESCRIPTION
## What changed

- Reduced the desktop homepage hero's maximum heading size.
- Tightened the hero's vertical padding and copy spacing at widths of 900px and above.
- Preserved the existing tablet and mobile presentation.

## Why

At 1280x720, the hero previously consumed the initial viewport and delayed catalog discovery. The tighter desktop treatment retains the editorial feel while allowing the first catalog card row to begin peeking above the fold.

## Validation

- `git diff --check`
- Headless Chromium measurement at 1280x720 confirmed the first catalog card begins at 718px within a 720px viewport.
