### PR TITLE
Deploy popularity tracking worker

### DIFF
--- a/DEV_README.md
+++ b/DEV_README.md
@@ -253,28 +253,27 @@ Anonymous, aggregate-only play/completion counters per lecture — no user ids, 
 
 | Piece | Location |
 |---|---|
-| Worker (POST /event, GET /popular) | `workers/popularity-worker.js` |
+| Worker (POST /event, GET /popular, GET /health) | `workers/popularity-worker.js` |
 | Wrangler config | `wrangler.popularity.jsonc` |
 | Browser client (beacons + cached counts) | `scripts/popularity.js` |
 | Play/complete beacons | `scripts/watch-page.js` |
 | "Popular right now" shelf | `renderPopularShelf` in `scripts/script.js` |
 
-The frontend degrades silently until the Worker is deployed: no errors, no shelf, no ranking boost. To deploy:
+The frontend degrades silently until the Worker is deployed: no errors, no shelf, no ranking boost. Wrangler provisions the declared `POPULARITY` KV namespace automatically on the first deployment, so no account-specific namespace ID belongs in the repository. To deploy:
 
 ```powershell
-npx wrangler kv namespace create POPULARITY
-# paste the returned namespace id into wrangler.popularity.jsonc
 npx wrangler deploy -c wrangler.popularity.jsonc
 ```
 
 To test the live Worker:
 
 ```powershell
+curl.exe -sS "https://improving-muslim-popularity.improving-muslim.workers.dev/health" -H "Origin: https://improvingmuslim.com"
 '{"key":"video:qadr-and-sabr","event":"play"}' | curl.exe -sS -i -X POST "https://improving-muslim-popularity.improving-muslim.workers.dev/event" -H "Content-Type: application/json" -H "Origin: https://improvingmuslim.com" --data-binary "@-"
 curl.exe -sS "https://improving-muslim-popularity.improving-muslim.workers.dev/popular" -H "Origin: https://improvingmuslim.com"
 ```
 
-Behavioral notes: the browser sends at most one play and one complete per lecture per device per day (localStorage dedupe); `GET /popular` is edge-cached for 15 minutes and the browser caches it in localStorage for 30 minutes; the shelf only appears once at least four lectures have 2+ plays. KV increments are read-modify-write, so rare concurrent plays can lose a count — acceptable for a best-effort signal. The Worker endpoint URL is a constant at the top of `scripts/popularity.js`.
+Behavioral notes: the browser sends at most one play and one complete per lecture per device per day (localStorage dedupe); the browser caches `GET /popular` in localStorage for 30 minutes; the shelf only appears once at least four lectures have 2+ plays. The response includes a 15-minute cache hint for a future custom-domain deployment, but the Cache API is deliberately not used because it is unavailable on `*.workers.dev`. KV increments are read-modify-write, so rare concurrent plays can lose a count — acceptable for a best-effort signal. The Worker endpoint URL is a constant at the top of `scripts/popularity.js`.
 
 ## Video Hosting Pattern
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "check:catalog": "node scripts/generate-catalog.js --check",
     "check:content": "node scripts/check-content.js",
     "check:js": "node scripts/check-js.js",
+    "check:workers": "node --test tests/popularity-worker.test.js",
     "check:seo-pages": "node scripts/generate-seo-pages.js --check",
     "check:sitemap": "node scripts/generate-sitemap.js --check",
     "check:transcript-index": "node scripts/generate-transcript-index.js --check",
@@ -22,7 +23,7 @@
     "sitemap": "node scripts/generate-sitemap.js",
     "transcript-index": "node scripts/generate-transcript-index.js",
     "clean-vtt": "node scripts/clean-vtt.js assets/captions",
-    "check": "npm run check:js && npm run check:content && npm run check:taxonomy && npm run check:a11y && npm run check:catalog && npm run check:transcript-index && npm run check:seo-pages && npm run check:sitemap && npm run check:vtt && npm run check:smoke"
+    "check": "npm run check:js && npm run check:workers && npm run check:content && npm run check:taxonomy && npm run check:a11y && npm run check:catalog && npm run check:transcript-index && npm run check:seo-pages && npm run check:sitemap && npm run check:vtt && npm run check:smoke"
   },
   "devDependencies": {
     "@playwright/test": "^1.61.1"

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -4,6 +4,7 @@ const isCI = Boolean(process.env.CI);
 
 export default defineConfig({
   testDir: "./tests",
+  testMatch: "**/*.spec.js",
   timeout: 20_000,
   expect: { timeout: 7_000 },
   fullyParallel: true,

--- a/tests/popularity-worker.test.js
+++ b/tests/popularity-worker.test.js
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import worker from "../workers/popularity-worker.js";
+
+const ORIGIN = "https://improvingmuslim.com";
+
+function createEnvironment() {
+  const values = new Map();
+
+  return {
+    env: {
+      ALLOWED_ORIGIN: ORIGIN,
+      POPULARITY: {
+        async get(key) {
+          return values.has(key) ? JSON.parse(values.get(key)) : null;
+        },
+        async list({ prefix = "", limit } = {}) {
+          const keys = Array.from(values.keys())
+            .filter((key) => key.startsWith(prefix))
+            .slice(0, limit || Infinity)
+            .map((name) => ({ name }));
+          return { keys, list_complete: true };
+        },
+        async put(key, value) {
+          values.set(key, value);
+        },
+      },
+    },
+    ctx: {},
+  };
+}
+
+function request(path, options = {}) {
+  return new Request(`https://popularity.example${path}`, {
+    ...options,
+    headers: { Origin: ORIGIN, ...(options.headers || {}) },
+  });
+}
+
+test("health confirms the Worker and KV binding", async () => {
+  const { env, ctx } = createEnvironment();
+  const response = await worker.fetch(request("/health"), env, ctx);
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), { ok: true, service: "popularity" });
+  assert.equal(response.headers.get("Access-Control-Allow-Origin"), ORIGIN);
+});
+
+test("play and completion events appear in the popularity response", async () => {
+  const { env, ctx } = createEnvironment();
+  const key = "video:purpose-of-creation";
+
+  for (const event of ["play", "play", "complete"]) {
+    const response = await worker.fetch(request("/event", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ key, event }),
+    }), env, ctx);
+    assert.equal(response.status, 204);
+  }
+
+  const response = await worker.fetch(request("/popular"), env, ctx);
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), { items: { [key]: { p: 2, c: 1 } } });
+});
+
+test("invalid events and unapproved origins are rejected", async () => {
+  const { env, ctx } = createEnvironment();
+  const invalidEvent = await worker.fetch(request("/event", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ key: "not-a-catalog-key", event: "play" }),
+  }), env, ctx);
+  assert.equal(invalidEvent.status, 400);
+
+  const wrongOrigin = new Request("https://popularity.example/popular", {
+    headers: { Origin: "https://example.com" },
+  });
+  const forbidden = await worker.fetch(wrongOrigin, env, ctx);
+  assert.equal(forbidden.status, 403);
+});

--- a/workers/popularity-worker.js
+++ b/workers/popularity-worker.js
@@ -7,7 +7,8 @@
  *   POST /event    body {"key":"episode:{slug}:{id}"|"video:{id}","event":"play"|"complete"}
  *                  increments the counter, returns 204
  *   GET  /popular  returns {"items":{"<key>":{"p":<plays>,"c":<completes>}}}
- *                  edge-cached for 15 minutes
+ *                  with a 15-minute cache hint for custom-domain deployments
+ *   GET  /health   confirms the Worker and KV binding are reachable
  *
  * Required bindings / vars (see wrangler.popularity.jsonc):
  * - POPULARITY: KV namespace for the counters
@@ -44,15 +45,12 @@ export default {
 
     const url = new URL(request.url);
 
-    if (request.method === "GET" && url.pathname === "/popular") {
-      // Serve from the edge cache so a burst of homepage visits costs one KV list.
-      const cache = caches.default;
-      const cacheKey = new Request(`${url.origin}/popular`);
-      const cached = await cache.match(cacheKey);
-      if (cached) {
-        return withCors(cached, corsHeaders);
-      }
+    if (request.method === "GET" && url.pathname === "/health") {
+      await env.POPULARITY.list({ limit: 1 });
+      return json({ ok: true, service: "popularity" }, 200, corsHeaders);
+    }
 
+    if (request.method === "GET" && url.pathname === "/popular") {
       const items = {};
       let cursor;
       do {
@@ -70,7 +68,6 @@ export default {
           "Cache-Control": `public, max-age=${POPULAR_CACHE_SECONDS}`,
         },
       });
-      ctx.waitUntil(cache.put(cacheKey, response.clone()));
       return withCors(response, corsHeaders);
     }
 

--- a/wrangler.popularity.jsonc
+++ b/wrangler.popularity.jsonc
@@ -5,12 +5,11 @@
   "compatibility_date": "2026-07-06",
   "workers_dev": true,
   "preview_urls": false,
-  // Create the namespace first, then paste its id here:
-  //   npx wrangler kv namespace create POPULARITY
+  // Wrangler provisions and binds this namespace on first deploy. Keeping the
+  // binding declarative avoids committing an account-specific namespace ID.
   "kv_namespaces": [
     {
-      "binding": "POPULARITY",
-      "id": "REPLACE_WITH_KV_NAMESPACE_ID"
+      "binding": "POPULARITY"
     }
   ],
   "vars": {


### PR DESCRIPTION
## What changed

- make the Popularity KV binding provisionable through Wrangler
- add a production health endpoint and remove the incompatible Cache API dependency
- add focused Worker tests for health, counters, validation, and CORS
- include Worker tests in the project check and keep Playwright scoped to browser specs
- update the deployment and verification documentation

## Why

The frontend referenced a Popularity Worker that did not exist in the connected Cloudflare account. The repository also contained a placeholder KV namespace ID, and the initial cached `/popular` implementation was incompatible with the `workers.dev` deployment surface.

## Impact

The Worker and KV namespace are now deployed. Production `/health` and `/popular` return 200, allowing play/completion signals and the Popular right now shelf to begin collecting data.

## Validation

- `npm run check:workers`
- `npm run check:js`
- 13 Playwright smoke tests pass when run individually/focused; the parallel full run exposed pre-existing intermittent failures in unrelated transition/Firebase sync assertions
- production `/health` returns 200
- production `/popular` returns 200
- invalid production event returns 400 without writing data