### PR TITLE
Improve mobile discovery and watch UX

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260720-mobile-ux" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script src="./scripts/error-handler.js?v=20260608-auth-hotfix"></script>
     <script type="application/ld+json">
@@ -238,7 +238,7 @@
     <script src="./scripts/home-search.js?v=20260718-episode-results" defer></script>
     <script src="./scripts/episode-search.js?v=20260718-episode-results" defer></script>
     <script src="./scripts/transcript-search.js?v=20260711-transcripts" defer></script>
-    <script src="./scripts/script.js?v=20260720-flat-feed" defer></script>
+    <script src="./scripts/script.js?v=20260720-mobile-discovery" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/pages/series-detail.html
+++ b/pages/series-detail.html
@@ -28,7 +28,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260720-mobile-ux" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <title>Series | Improving Muslim</title>
   </head>

--- a/pages/watch.html
+++ b/pages/watch.html
@@ -33,7 +33,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260720-mobile-ux" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script src="./scripts/error-handler.js?v=20260608-auth-hotfix"></script>
     <title>Watch | Improving Muslim</title>
@@ -193,40 +193,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -299,7 +307,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/scripts/script.js
+++ b/scripts/script.js
@@ -193,10 +193,31 @@ function homeCardIdentity(item) {
   return item.contentType === "video" ? `video:${item.sourceId}` : `series:${item._seriesSlug}`;
 }
 
+function getDiscoveryHomeOrder(list) {
+  const shuffledSeries = list
+    .filter((item) => item.contentType !== "video")
+    .sort((a, b) => stableRandomKey(a.title) - stableRandomKey(b.title));
+  const shuffledVideos = list
+    .filter((item) => item.contentType === "video")
+    .sort((a, b) => stableRandomKey(a.title) - stableRandomKey(b.title));
+  const mixed = [];
+
+  // Keep the first impression balanced: series are the platform's strongest
+  // differentiator, while standalone lectures still appear throughout the
+  // feed. Starting with a series also gives mobile visitors the clearest cue
+  // that this is more than a conventional video feed.
+  while (shuffledSeries.length || shuffledVideos.length) {
+    if (shuffledSeries.length) mixed.push(shuffledSeries.shift());
+    if (shuffledVideos.length) mixed.push(shuffledVideos.shift());
+  }
+
+  return mixed;
+}
+
 function getPersonalizedHomeOrder(list) {
   const catalogItems = window.catalogIndex?.items || [];
   if (!window.IMRelated || !catalogItems.length) {
-    return { items: getSortedSeries(list), personalized: false };
+    return { items: getDiscoveryHomeOrder(list), personalized: false };
   }
 
   const itemByProgressKey = new Map(
@@ -216,7 +237,7 @@ function getPersonalizedHomeOrder(list) {
     .slice(0, 3);
 
   if (!seeds.length) {
-    return { items: getSortedSeries(list), personalized: false };
+    return { items: getDiscoveryHomeOrder(list), personalized: false };
   }
 
   const popularity = window.IMPopularity ? window.IMPopularity.cachedCounts() : {};
@@ -255,7 +276,7 @@ function getPersonalizedHomeOrder(list) {
       return difference || stableRandomKey(a.title) - stableRandomKey(b.title);
     });
   if (!relevant.length) {
-    return { items: getSortedSeries(list), personalized: false };
+    return { items: getDiscoveryHomeOrder(list), personalized: false };
   }
 
   // Cap the recommendation pool and interleave one discovery card after every
@@ -1229,7 +1250,7 @@ function renderSeries() {
     els.seriesTitle.textContent = isSearching
       ? `Search results for "${state.searchTerm}"`
       : state.activeCategory === "foryou"
-      ? "For you"
+      ? personalizedHome ? "For you" : "Discover"
       : "Lectures and series";
   }
   els.seriesGrid.dataset.feedMode = personalizedHome ? "personalized" : "discovery";
@@ -1304,7 +1325,7 @@ function renderSeries() {
             ${state.aiSearch.reasonById[searchItemId(item)] ? `<span class="label-badge label-ai">AI match</span>` : ""}
             ${item._badge
               ? `<span class="avail-badge ${item._badge.cls}">${escapeHtml(item._badge.text)}</span>`
-              : item.episodes ? `<span class="avail-badge-plain ${item.episodesCls || ''}">${escapeHtml(item.episodes)}</span>` : ""
+              : !isVideo && item.episodes ? `<span class="avail-badge-plain ${item.episodesCls || ''}">${escapeHtml(item.episodes)}</span>` : ""
             }
             <button class="card-menu-trigger" type="button" aria-label="More options" aria-expanded="false">
               <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 4a2 2 0 100 4 2 2 0 000-4Zm0 6a2 2 0 100 4 2 2 0 000-4Zm0 6a2 2 0 100 4 2 2 0 000-4Z"/></svg>

--- a/scripts/watch-page.js
+++ b/scripts/watch-page.js
@@ -105,6 +105,8 @@ const grammarNotesPanel = document.querySelector("#grammar-notes-panel");
 const grammarNotesBody = document.querySelector("#watch-grammar-notes");
 const takeawaysPanel = document.querySelector("#takeaways-panel");
 const takeawaysList = document.querySelector("#watch-takeaways .takeaway-list");
+const notesPanel = document.querySelector(".notes-panel");
+const notesPanelToggle = document.querySelector("#notes-panel-toggle");
 const notesTextarea = document.querySelector("#notes-textarea");
 const notesEditView = document.querySelector("#notes-edit-view");
 const notesPreviewView = document.querySelector("#notes-preview-view");
@@ -576,6 +578,25 @@ if (notesTextarea) {
 
   // Load saved note and keep it saved shortly after the user stops typing.
   notesTextarea.value = readNote().text || "";
+
+  function setNotesPanelCollapsed(collapsed) {
+    if (!notesPanel || !notesPanelToggle) return;
+    notesPanel.classList.toggle("is-collapsed", collapsed);
+    notesPanelToggle.setAttribute("aria-expanded", String(!collapsed));
+    notesPanelToggle.setAttribute("aria-label", collapsed ? "Open notes editor" : "Collapse notes editor");
+  }
+
+  // Empty editors start compact on phones so takeaways, recaps, and the next
+  // lecture remain close to the player. Existing notes always open in full.
+  setNotesPanelCollapsed(
+    window.matchMedia?.("(max-width: 600px)").matches && !notesTextarea.value.trim(),
+  );
+
+  notesPanelToggle?.addEventListener("click", () => {
+    const shouldCollapse = !notesPanel.classList.contains("is-collapsed");
+    setNotesPanelCollapsed(shouldCollapse);
+    if (!shouldCollapse) notesTextarea.focus();
+  });
 
   let notesSaveTimer = null;
   let notesStatusClearTimer = null;

--- a/series/angels-in-your-presence/index.html
+++ b/series/angels-in-your-presence/index.html
@@ -29,7 +29,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {

--- a/series/change-of-heart/index.html
+++ b/series/change-of-heart/index.html
@@ -29,7 +29,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {

--- a/series/enjoy-your-prayer/index.html
+++ b/series/enjoy-your-prayer/index.html
@@ -29,7 +29,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {

--- a/series/fortress-of-the-muslim/index.html
+++ b/series/fortress-of-the-muslim/index.html
@@ -29,7 +29,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {

--- a/series/forty-hadith-nawawi/index.html
+++ b/series/forty-hadith-nawawi/index.html
@@ -29,7 +29,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {

--- a/series/life-of-muhammad-mufti-menk/index.html
+++ b/series/life-of-muhammad-mufti-menk/index.html
@@ -29,7 +29,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {

--- a/series/madina-arabic/index.html
+++ b/series/madina-arabic/index.html
@@ -29,7 +29,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {

--- a/series/page-by-page/index.html
+++ b/series/page-by-page/index.html
@@ -29,7 +29,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {

--- a/series/seerah-yasir-qadhi/index.html
+++ b/series/seerah-yasir-qadhi/index.html
@@ -29,7 +29,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {

--- a/series/stories-of-the-prophets/index.html
+++ b/series/stories-of-the-prophets/index.html
@@ -29,7 +29,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {

--- a/series/ten-promised-jannah/index.html
+++ b/series/ten-promised-jannah/index.html
@@ -29,7 +29,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {

--- a/series/why-me/index.html
+++ b/series/why-me/index.html
@@ -29,7 +29,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {

--- a/styles/cards.css
+++ b/styles/cards.css
@@ -6,9 +6,21 @@
   gap: 8px;
   overflow-x: auto;
   padding: 4px 0 12px;
-  scrollbar-width: thin;
+  -webkit-overflow-scrolling: touch;
   -webkit-mask-image: linear-gradient(to right, black 0%, black calc(100% - 52px), transparent 100%);
   mask-image: linear-gradient(to right, black 0%, black calc(100% - 52px), transparent 100%);
+}
+
+.speaker-strip {
+  scrollbar-width: thin;
+}
+
+.category-strip {
+  scrollbar-width: none;
+}
+
+.category-strip::-webkit-scrollbar {
+  display: none;
 }
 
 /* Desktop has room to show every topic — wrap instead of scroll */

--- a/styles/responsive.css
+++ b/styles/responsive.css
@@ -790,6 +790,9 @@
 
   .result-count {
     margin-top: 8px;
+    max-width: 100%;
+    white-space: normal;
+    overflow-wrap: anywhere;
   }
 
   .catalog-pagination {

--- a/styles/series-detail.css
+++ b/styles/series-detail.css
@@ -60,6 +60,27 @@
   margin-bottom: 20px;
 }
 
+@media (max-width: 600px) {
+  .ep-filter-row {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    margin-right: -16px;
+    padding: 0 16px 4px 0;
+    scrollbar-width: none;
+    -webkit-overflow-scrolling: touch;
+    -webkit-mask-image: linear-gradient(to right, black 0%, black calc(100% - 36px), transparent 100%);
+    mask-image: linear-gradient(to right, black 0%, black calc(100% - 36px), transparent 100%);
+  }
+
+  .ep-filter-row::-webkit-scrollbar {
+    display: none;
+  }
+
+  .ep-filter-btn {
+    flex: 0 0 auto;
+  }
+}
+
 .ep-filter-btn {
   padding: 6px 14px;
   border-radius: 999px;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -5,19 +5,19 @@
 
 @import "./base.css?v=20260706-search-ux";          /* CSS custom properties, reset, sr-only, is-hidden  */
 @import "./nav.css?v=20260706-streak-ranks"; /* Site header, top nav, bottom mobile nav             */
-@import "./layout.css?v=20260720-desktop-polish";        /* Hero, content-section wrappers, section headings   */
+@import "./layout.css?v=20260720-mobile-ux";        /* Hero, content-section wrappers, section headings   */
 @import "./home.css?v=20260718-episode-results";          /* Continue-watching strip & cards                    */
-@import "./cards.css?v=20260720-desktop-polish";   /* Series cards, speaker cards, category filters      */
+@import "./cards.css?v=20260720-mobile-ux";   /* Series cards, speaker cards, category filters      */
 @import "./components.css?v=20260702-dark-1"; /* Shared UI: buttons, panels, sort, footer, errors  */
 @import "./about.css";         /* About page                                         */
 @import "./settings.css?v=20260706-streak-ranks";  /* Settings page, toggle switch, themed select        */
 @import "./feedback.css";      /* Feedback page & form                               */
 @import "./explore.css?v=20260720-desktop-polish"; /* Explore and focused category discovery       */
-@import "./series-detail.css?v=20260720-episode-4col";        /* Series/speaker hero, episode list & cards   */
-@import "./watch.css?v=20260720-desktop-polish";  /* Video player, watch layout, sidebar, autoplay, notes */
+@import "./series-detail.css?v=20260720-mobile-ux";        /* Series/speaker hero, episode list & cards   */
+@import "./watch.css?v=20260720-mobile-ux";  /* Video player, watch layout, sidebar, autoplay, notes */
 @import "./animations.css";    /* Keyframes, skeletons, scroll reveal, motion prefs  */
 @import "./dark.css";          /* Grouped cross-page dark-mode overrides             */
-@import "./responsive.css?v=20260720-header-fit"; /* Breakpoint overrides (≤900px, ≤600px)   */
+@import "./responsive.css?v=20260720-mobile-ux"; /* Breakpoint overrides (≤900px, ≤600px)   */
 @import "./history.css?v=20260627-relative-time";    /* Watch history page                            */
 @import "./saved.css?v=20260627-grouped-saved";      /* Saved items page                              */
 @import "./roadmap.css";       /* Roadmap page                                       */

--- a/styles/watch.css
+++ b/styles/watch.css
@@ -522,6 +522,15 @@
   color: var(--ink);
 }
 
+.notes-panel-title {
+  min-width: 0;
+}
+
+.notes-panel-summary,
+.notes-panel-toggle {
+  display: none;
+}
+
 .notes-tabs {
   display: flex;
   flex-shrink: 0;
@@ -719,6 +728,75 @@
 .notes-clear-btn:focus-visible {
   color: var(--rose);
   outline: none;
+}
+
+@media (max-width: 600px) {
+  .notes-panel-head {
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .notes-panel-title {
+    flex: 1 1 auto;
+  }
+
+  .notes-panel-summary {
+    color: var(--muted);
+    font-size: 0.78rem;
+    font-weight: 600;
+    line-height: 1.35;
+  }
+
+  .notes-panel-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    height: 40px;
+    margin: -8px -8px -8px 0;
+    border: 0;
+    border-radius: 50%;
+    background: transparent;
+    color: var(--muted);
+  }
+
+  .notes-panel-toggle:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: -3px;
+  }
+
+  .notes-panel-toggle svg {
+    transition: transform 160ms ease;
+  }
+
+  .notes-tabs {
+    order: 3;
+    margin-left: auto;
+  }
+
+  .notes-panel.is-collapsed {
+    padding-top: 13px;
+    padding-bottom: 13px;
+  }
+
+  .notes-panel.is-collapsed .notes-panel-head {
+    align-items: center;
+    margin-bottom: 0;
+  }
+
+  .notes-panel.is-collapsed .notes-panel-summary {
+    display: block;
+    margin-top: 2px;
+  }
+
+  .notes-panel.is-collapsed .notes-panel-toggle svg {
+    transform: rotate(-90deg);
+  }
+
+  .notes-panel.is-collapsed .notes-tabs,
+  .notes-panel.is-collapsed .notes-panel-body {
+    display: none;
+  }
 }
 
 /* ─── Related lectures (sidebar) ────────────────────────────────────────── */

--- a/tests/smoke.spec.js
+++ b/tests/smoke.spec.js
@@ -182,8 +182,13 @@ test("homepage renders and supports search and topic filtering", async ({ page }
   );
   await expect(page.getByRole("searchbox", { name: "Search lectures" })).toBeVisible();
   await expectCatalog(page);
-  await expect(page.getByRole("heading", { level: 2, name: "For you" })).toBeVisible();
+  await expect(page.getByRole("heading", { level: 2, name: "Discover" })).toBeVisible();
   await expect(page.locator("#series-grid")).toHaveAttribute("data-feed-mode", "discovery");
+  const discoveryTypes = await page.locator("#series-grid .series-title").evaluateAll((links) =>
+    links.slice(0, 4).map((link) => link.getAttribute("href").includes("/series/") ? "series" : "video"),
+  );
+  expect(discoveryTypes).toEqual(["series", "video", "series", "video"]);
+  await expect(page.locator("#series-grid").getByText("Standalone Video", { exact: true })).toHaveCount(0);
 
   const prayerFilter = page.getByRole("button", { name: "Prayer", exact: true });
   await prayerFilter.click();
@@ -933,6 +938,37 @@ test.describe("mobile navigation", () => {
     );
     expect(hasHorizontalOverflow).toBe(false);
     await expect(page.locator(".bottom-nav")).toBeVisible();
+    expect(pageErrors).toEqual([]);
+  });
+
+  test("keeps mobile search, notes, and episode filters compact", async ({ page }) => {
+    const pageErrors = await preparePage(page);
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+
+    const search = page.getByRole("searchbox", { name: "Search lectures" });
+    await search.fill("sabr");
+    await search.press("Enter");
+    await expect(page.getByRole("heading", { level: 2, name: 'Search results for "sabr"' })).toBeVisible();
+    await expect.poll(() => page.evaluate(
+      () => document.documentElement.scrollWidth <= document.documentElement.clientWidth,
+    )).toBe(true);
+
+    await page.goto("/watch/change-of-heart/vLb4YF-0F5M/", { waitUntil: "domcontentloaded" });
+    const notesPanel = page.locator(".notes-panel");
+    const notesToggle = page.getByRole("button", { name: "Open notes editor" });
+    await expect(notesPanel).toHaveClass(/\bis-collapsed\b/);
+    await expect(page.locator("#notes-panel-body")).toBeHidden();
+    await notesToggle.click();
+    await expect(page.locator("#notes-panel-body")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Collapse notes editor" })).toHaveAttribute("aria-expanded", "true");
+
+    await page.goto("/series/change-of-heart/", { waitUntil: "domcontentloaded" });
+    await expect(page.locator("#episode-filters-row .ep-filter-btn")).toHaveCount(4);
+    const filterLayout = await page.locator("#episode-filters-row").evaluate((row) => ({
+      flexWrap: getComputedStyle(row).flexWrap,
+      withinViewport: document.documentElement.scrollWidth <= document.documentElement.clientWidth,
+    }));
+    expect(filterLayout).toEqual({ flexWrap: "nowrap", withinViewport: true });
     expect(pageErrors).toEqual([]);
   });
 });

--- a/watch/angels-in-your-presence/9VtsVxVyn1g/index.html
+++ b/watch/angels-in-your-presence/9VtsVxVyn1g/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -556,7 +564,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/angels-in-your-presence/MXWlFL4fWI4/index.html
+++ b/watch/angels-in-your-presence/MXWlFL4fWI4/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -556,7 +564,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/angels-in-your-presence/NDfvYIG4Dr4/index.html
+++ b/watch/angels-in-your-presence/NDfvYIG4Dr4/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -556,7 +564,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/angels-in-your-presence/Ulkz2JIAqEw/index.html
+++ b/watch/angels-in-your-presence/Ulkz2JIAqEw/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -556,7 +564,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/angels-in-your-presence/W7gEyqqSPpU/index.html
+++ b/watch/angels-in-your-presence/W7gEyqqSPpU/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -556,7 +564,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/angels-in-your-presence/gOtXMstUHCU/index.html
+++ b/watch/angels-in-your-presence/gOtXMstUHCU/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -556,7 +564,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/angels-in-your-presence/mOuiRGRIhak/index.html
+++ b/watch/angels-in-your-presence/mOuiRGRIhak/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -556,7 +564,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/angels-in-your-presence/rMCbdcH3qSk/index.html
+++ b/watch/angels-in-your-presence/rMCbdcH3qSk/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -556,7 +564,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/angels-in-your-presence/swoO1nd2VKw/index.html
+++ b/watch/angels-in-your-presence/swoO1nd2VKw/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -556,7 +564,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/angels-in-your-presence/wHYlw82qDAE/index.html
+++ b/watch/angels-in-your-presence/wHYlw82qDAE/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -556,7 +564,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/angels-in-your-presence/wuhFCf6eifE/index.html
+++ b/watch/angels-in-your-presence/wuhFCf6eifE/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -556,7 +564,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/change-of-heart/4mUe_i19dlE/index.html
+++ b/watch/change-of-heart/4mUe_i19dlE/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -444,7 +452,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/change-of-heart/LBvKNhyufQg/index.html
+++ b/watch/change-of-heart/LBvKNhyufQg/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -444,7 +452,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/change-of-heart/PRnxCiJpV6Q/index.html
+++ b/watch/change-of-heart/PRnxCiJpV6Q/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -444,7 +452,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/change-of-heart/YajMLwVorxA/index.html
+++ b/watch/change-of-heart/YajMLwVorxA/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -444,7 +452,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/change-of-heart/ZaOvrx0B-3I/index.html
+++ b/watch/change-of-heart/ZaOvrx0B-3I/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -444,7 +452,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/change-of-heart/diqdqrYnuMQ/index.html
+++ b/watch/change-of-heart/diqdqrYnuMQ/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -444,7 +452,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/change-of-heart/r9CjYq15I8g/index.html
+++ b/watch/change-of-heart/r9CjYq15I8g/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -444,7 +452,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/change-of-heart/s4BB5b98YjU/index.html
+++ b/watch/change-of-heart/s4BB5b98YjU/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -444,7 +452,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/change-of-heart/tcBUIvcsQrc/index.html
+++ b/watch/change-of-heart/tcBUIvcsQrc/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -444,7 +452,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/change-of-heart/vLb4YF-0F5M/index.html
+++ b/watch/change-of-heart/vLb4YF-0F5M/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -444,7 +452,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/enjoy-your-prayer/FbTrDp4xhu0/index.html
+++ b/watch/enjoy-your-prayer/FbTrDp4xhu0/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -484,7 +492,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/enjoy-your-prayer/GUt98wgMo-4/index.html
+++ b/watch/enjoy-your-prayer/GUt98wgMo-4/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -484,7 +492,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/enjoy-your-prayer/J0-j61fwIoU/index.html
+++ b/watch/enjoy-your-prayer/J0-j61fwIoU/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -484,7 +492,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/enjoy-your-prayer/R8KKme0b-8s/index.html
+++ b/watch/enjoy-your-prayer/R8KKme0b-8s/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -484,7 +492,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/enjoy-your-prayer/Rl-lXxpcDHM/index.html
+++ b/watch/enjoy-your-prayer/Rl-lXxpcDHM/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -484,7 +492,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/enjoy-your-prayer/UkjFC0upHyU/index.html
+++ b/watch/enjoy-your-prayer/UkjFC0upHyU/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -484,7 +492,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/enjoy-your-prayer/VfCT_g75yEE/index.html
+++ b/watch/enjoy-your-prayer/VfCT_g75yEE/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -484,7 +492,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/enjoy-your-prayer/YYpD2ltaIaQ/index.html
+++ b/watch/enjoy-your-prayer/YYpD2ltaIaQ/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -484,7 +492,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/fortress-of-the-muslim/5aDUOmJrqLM/index.html
+++ b/watch/fortress-of-the-muslim/5aDUOmJrqLM/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -210,40 +210,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -421,7 +429,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/fortress-of-the-muslim/7gNIZDVHtfw/index.html
+++ b/watch/fortress-of-the-muslim/7gNIZDVHtfw/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -210,40 +210,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -421,7 +429,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/fortress-of-the-muslim/Xi4qsfFAsqY/index.html
+++ b/watch/fortress-of-the-muslim/Xi4qsfFAsqY/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -210,40 +210,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -421,7 +429,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/fortress-of-the-muslim/eLpWlhlQgcY/index.html
+++ b/watch/fortress-of-the-muslim/eLpWlhlQgcY/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -210,40 +210,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -421,7 +429,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/fortress-of-the-muslim/r6t15aCtwNk/index.html
+++ b/watch/fortress-of-the-muslim/r6t15aCtwNk/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -210,40 +210,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -421,7 +429,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/forty-hadith-nawawi/3p4P6ZttAcI/index.html
+++ b/watch/forty-hadith-nawawi/3p4P6ZttAcI/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -684,7 +692,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/forty-hadith-nawawi/MfsG8-Ica3M/index.html
+++ b/watch/forty-hadith-nawawi/MfsG8-Ica3M/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -684,7 +692,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/forty-hadith-nawawi/d62t_mwIGtQ/index.html
+++ b/watch/forty-hadith-nawawi/d62t_mwIGtQ/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -684,7 +692,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/forty-hadith-nawawi/zfB-6Btl0Gg/index.html
+++ b/watch/forty-hadith-nawawi/zfB-6Btl0Gg/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -684,7 +692,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/life-of-muhammad-mufti-menk/1YkPik5y1Gw/index.html
+++ b/watch/life-of-muhammad-mufti-menk/1YkPik5y1Gw/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -556,7 +564,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/life-of-muhammad-mufti-menk/5iwZPhswyKI/index.html
+++ b/watch/life-of-muhammad-mufti-menk/5iwZPhswyKI/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -556,7 +564,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/life-of-muhammad-mufti-menk/6LOE8bLQVyM/index.html
+++ b/watch/life-of-muhammad-mufti-menk/6LOE8bLQVyM/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -556,7 +564,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/life-of-muhammad-mufti-menk/B_S-eVQoWUc/index.html
+++ b/watch/life-of-muhammad-mufti-menk/B_S-eVQoWUc/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -556,7 +564,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/life-of-muhammad-mufti-menk/CO0ETi5nFiQ/index.html
+++ b/watch/life-of-muhammad-mufti-menk/CO0ETi5nFiQ/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -556,7 +564,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/life-of-muhammad-mufti-menk/CPXhZDmLuuw/index.html
+++ b/watch/life-of-muhammad-mufti-menk/CPXhZDmLuuw/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -556,7 +564,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/life-of-muhammad-mufti-menk/DgxeLiDDchs/index.html
+++ b/watch/life-of-muhammad-mufti-menk/DgxeLiDDchs/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -556,7 +564,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/life-of-muhammad-mufti-menk/DvnHP73yUPc/index.html
+++ b/watch/life-of-muhammad-mufti-menk/DvnHP73yUPc/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -556,7 +564,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/life-of-muhammad-mufti-menk/JziOUZOSqn8/index.html
+++ b/watch/life-of-muhammad-mufti-menk/JziOUZOSqn8/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -556,7 +564,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/life-of-muhammad-mufti-menk/Li3FwpFDePg/index.html
+++ b/watch/life-of-muhammad-mufti-menk/Li3FwpFDePg/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -556,7 +564,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/life-of-muhammad-mufti-menk/NPxGHFNK31I/index.html
+++ b/watch/life-of-muhammad-mufti-menk/NPxGHFNK31I/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -556,7 +564,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/life-of-muhammad-mufti-menk/OF7gkEpHayA/index.html
+++ b/watch/life-of-muhammad-mufti-menk/OF7gkEpHayA/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -556,7 +564,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/life-of-muhammad-mufti-menk/VO22l6-Qkys/index.html
+++ b/watch/life-of-muhammad-mufti-menk/VO22l6-Qkys/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -556,7 +564,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/life-of-muhammad-mufti-menk/W2usJgjOSrQ/index.html
+++ b/watch/life-of-muhammad-mufti-menk/W2usJgjOSrQ/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -556,7 +564,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/life-of-muhammad-mufti-menk/WbL6fwsxwLs/index.html
+++ b/watch/life-of-muhammad-mufti-menk/WbL6fwsxwLs/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -556,7 +564,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/life-of-muhammad-mufti-menk/YudEqpMmjVY/index.html
+++ b/watch/life-of-muhammad-mufti-menk/YudEqpMmjVY/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -556,7 +564,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/life-of-muhammad-mufti-menk/pSj_iJ8_1cE/index.html
+++ b/watch/life-of-muhammad-mufti-menk/pSj_iJ8_1cE/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -556,7 +564,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/life-of-muhammad-mufti-menk/wMJPAH1s4BA/index.html
+++ b/watch/life-of-muhammad-mufti-menk/wMJPAH1s4BA/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -556,7 +564,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/madina-arabic/DtppWNZPEHs/index.html
+++ b/watch/madina-arabic/DtppWNZPEHs/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -210,40 +210,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -1357,7 +1365,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/madina-arabic/FjxPGUZ70Cw/index.html
+++ b/watch/madina-arabic/FjxPGUZ70Cw/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -210,40 +210,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -1301,7 +1309,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/madina-arabic/QdcNa0YNM-g/index.html
+++ b/watch/madina-arabic/QdcNa0YNM-g/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -210,40 +210,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -1420,7 +1428,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/page-by-page/YMNEgAGqAIk/index.html
+++ b/watch/page-by-page/YMNEgAGqAIk/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -452,7 +460,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/page-by-page/v0r76TgXL4E/index.html
+++ b/watch/page-by-page/v0r76TgXL4E/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -452,7 +460,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/page-by-page/zCniltPLzsg/index.html
+++ b/watch/page-by-page/zCniltPLzsg/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -452,7 +460,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/seerah-yasir-qadhi/4F5qzMI2IKs/index.html
+++ b/watch/seerah-yasir-qadhi/4F5qzMI2IKs/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -1148,7 +1156,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/seerah-yasir-qadhi/629isa8LujE/index.html
+++ b/watch/seerah-yasir-qadhi/629isa8LujE/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -1148,7 +1156,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/seerah-yasir-qadhi/VOUp3ZZ9t3A/index.html
+++ b/watch/seerah-yasir-qadhi/VOUp3ZZ9t3A/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -1148,7 +1156,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/seerah-yasir-qadhi/ey7UAi_Emgs/index.html
+++ b/watch/seerah-yasir-qadhi/ey7UAi_Emgs/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -1148,7 +1156,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/seerah-yasir-qadhi/udjM4dBVicE/index.html
+++ b/watch/seerah-yasir-qadhi/udjM4dBVicE/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -1148,7 +1156,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/standalone/17-lessons-from-musa-and-khidr/index.html
+++ b/watch/standalone/17-lessons-from-musa-and-khidr/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -210,40 +210,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -318,7 +326,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/standalone/7-commandments-to-a-successful-marriage/index.html
+++ b/watch/standalone/7-commandments-to-a-successful-marriage/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -210,40 +210,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -318,7 +326,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/standalone/ahmed-the-repenter/index.html
+++ b/watch/standalone/ahmed-the-repenter/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -210,40 +210,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -318,7 +326,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/standalone/allahs-words-to-musa-were-meant-for-you-too/index.html
+++ b/watch/standalone/allahs-words-to-musa-were-meant-for-you-too/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -210,40 +210,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -318,7 +326,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/standalone/approaching-the-quran-mind-soul-and-limbs/index.html
+++ b/watch/standalone/approaching-the-quran-mind-soul-and-limbs/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -210,40 +210,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -318,7 +326,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/standalone/can-a-muslim-get-rich/index.html
+++ b/watch/standalone/can-a-muslim-get-rich/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -210,40 +210,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -318,7 +326,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/standalone/dua-how-to-get-your-dreams/index.html
+++ b/watch/standalone/dua-how-to-get-your-dreams/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -210,40 +210,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -318,7 +326,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/standalone/effect-of-the-quran-in-our-life/index.html
+++ b/watch/standalone/effect-of-the-quran-in-our-life/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -210,40 +210,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -318,7 +326,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/standalone/four-stages-of-allahs-guidance/index.html
+++ b/watch/standalone/four-stages-of-allahs-guidance/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -210,40 +210,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -318,7 +326,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/standalone/how-shaytaan-plans-to-destroy-you/index.html
+++ b/watch/standalone/how-shaytaan-plans-to-destroy-you/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -210,40 +210,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -318,7 +326,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/standalone/never-give-up-on-dua/index.html
+++ b/watch/standalone/never-give-up-on-dua/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -210,40 +210,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -318,7 +326,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/standalone/only-allah-knows-what-you-went-through/index.html
+++ b/watch/standalone/only-allah-knows-what-you-went-through/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -210,40 +210,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -318,7 +326,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/standalone/path-to-prestige-and-respect/index.html
+++ b/watch/standalone/path-to-prestige-and-respect/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -210,40 +210,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -318,7 +326,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/standalone/poem-to-soften-the-hardened-heart/index.html
+++ b/watch/standalone/poem-to-soften-the-hardened-heart/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -210,40 +210,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -318,7 +326,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/standalone/purpose-of-creation/index.html
+++ b/watch/standalone/purpose-of-creation/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -210,40 +210,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -318,7 +326,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/standalone/qadr-and-sabr/index.html
+++ b/watch/standalone/qadr-and-sabr/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -210,40 +210,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -318,7 +326,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/standalone/quran-and-depression/index.html
+++ b/watch/standalone/quran-and-depression/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -210,40 +210,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -318,7 +326,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/standalone/quran-your-best-companion/index.html
+++ b/watch/standalone/quran-your-best-companion/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -210,40 +210,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -318,7 +326,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/standalone/six-lessons-from-the-destroyed-garden/index.html
+++ b/watch/standalone/six-lessons-from-the-destroyed-garden/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -210,40 +210,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -318,7 +326,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/standalone/story-of-prophet-ayyub/index.html
+++ b/watch/standalone/story-of-prophet-ayyub/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -210,40 +210,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -318,7 +326,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/standalone/story-of-prophet-yunus/index.html
+++ b/watch/standalone/story-of-prophet-yunus/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -210,40 +210,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -318,7 +326,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/standalone/story-of-prophet-zakariya/index.html
+++ b/watch/standalone/story-of-prophet-zakariya/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -210,40 +210,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -318,7 +326,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/standalone/story-of-the-three-trapped-men/index.html
+++ b/watch/standalone/story-of-the-three-trapped-men/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -210,40 +210,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -318,7 +326,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/standalone/surah-that-beautifies-your-character/index.html
+++ b/watch/standalone/surah-that-beautifies-your-character/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -210,40 +210,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -318,7 +326,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/standalone/ten-lessons-from-musa-and-khidr/index.html
+++ b/watch/standalone/ten-lessons-from-musa-and-khidr/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -210,40 +210,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -318,7 +326,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/standalone/why-am-i-here/index.html
+++ b/watch/standalone/why-am-i-here/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -210,40 +210,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -318,7 +326,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/standalone/worried-about-things/index.html
+++ b/watch/standalone/worried-about-things/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -210,40 +210,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -318,7 +326,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/stories-of-the-prophets/IQjzErJlpJ0/index.html
+++ b/watch/stories-of-the-prophets/IQjzErJlpJ0/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -210,40 +210,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -549,7 +557,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/stories-of-the-prophets/J9IDLOza_KM/index.html
+++ b/watch/stories-of-the-prophets/J9IDLOza_KM/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -210,40 +210,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -549,7 +557,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/stories-of-the-prophets/WNPjOOwXOIk/index.html
+++ b/watch/stories-of-the-prophets/WNPjOOwXOIk/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -210,40 +210,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -549,7 +557,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/stories-of-the-prophets/mknf5MB1qDI/index.html
+++ b/watch/stories-of-the-prophets/mknf5MB1qDI/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -210,40 +210,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -549,7 +557,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/ten-promised-jannah/4cT7BoQPLm8/index.html
+++ b/watch/ten-promised-jannah/4cT7BoQPLm8/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -396,7 +404,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/ten-promised-jannah/5W5Mpg3BAO8/index.html
+++ b/watch/ten-promised-jannah/5W5Mpg3BAO8/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -396,7 +404,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/ten-promised-jannah/KyvurEQBiZU/index.html
+++ b/watch/ten-promised-jannah/KyvurEQBiZU/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -396,7 +404,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/ten-promised-jannah/zRzcXWU0VLo/index.html
+++ b/watch/ten-promised-jannah/zRzcXWU0VLo/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -396,7 +404,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/ten-promised-jannah/zrRSP4feVmY/index.html
+++ b/watch/ten-promised-jannah/zrRSP4feVmY/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -396,7 +404,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/why-me/1E76SyachR4/index.html
+++ b/watch/why-me/1E76SyachR4/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -556,7 +564,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/why-me/5hDUB6yFwBQ/index.html
+++ b/watch/why-me/5hDUB6yFwBQ/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -556,7 +564,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/why-me/Ffg9fO_NXZA/index.html
+++ b/watch/why-me/Ffg9fO_NXZA/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -556,7 +564,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/why-me/I6VBsllL0bI/index.html
+++ b/watch/why-me/I6VBsllL0bI/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -556,7 +564,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/why-me/JpwDs25yrRc/index.html
+++ b/watch/why-me/JpwDs25yrRc/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -556,7 +564,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/why-me/L6caeSh2bd8/index.html
+++ b/watch/why-me/L6caeSh2bd8/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -556,7 +564,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/why-me/N9larZxwXcc/index.html
+++ b/watch/why-me/N9larZxwXcc/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -556,7 +564,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/why-me/SGdznSHyJUQ/index.html
+++ b/watch/why-me/SGdznSHyJUQ/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -556,7 +564,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/why-me/UwK4rsBRXuI/index.html
+++ b/watch/why-me/UwK4rsBRXuI/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -556,7 +564,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/why-me/abp-0PHtHCg/index.html
+++ b/watch/why-me/abp-0PHtHCg/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -556,7 +564,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/why-me/pXx8Bk1C-VU/index.html
+++ b/watch/why-me/pXx8Bk1C-VU/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -556,7 +564,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/why-me/uzE5j2qkFA0/index.html
+++ b/watch/why-me/uzE5j2qkFA0/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -556,7 +564,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">

--- a/watch/why-me/xbp_whdYYIw/index.html
+++ b/watch/why-me/xbp_whdYYIw/index.html
@@ -30,7 +30,7 @@
       href="https://fonts.googleapis.com/css2?family=Inria+Serif:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles/styles.css?v=20260720-episode-4col" />
+    <link rel="stylesheet" href="./styles/styles.css?v=20260711-related" />
     <script src="./scripts/theme.js?v=20260705-system-theme"></script>
     <script type="application/ld+json">
       {
@@ -209,40 +209,48 @@
 
           <section class="notes-panel" aria-labelledby="notes-heading">
             <div class="notes-panel-head">
-              <h2 id="notes-heading">My Notes</h2>
+              <div class="notes-panel-title">
+                <h2 id="notes-heading">My Notes</h2>
+                <span class="notes-panel-summary">Add a note while you watch</span>
+              </div>
+              <button class="notes-panel-toggle" id="notes-panel-toggle" type="button" aria-expanded="true" aria-controls="notes-panel-body" aria-label="Collapse notes editor">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
               <div class="notes-tabs" role="tablist" aria-label="Notes view">
                 <button type="button" role="tab" class="is-active" data-notes-tab="edit" aria-selected="true">Edit</button>
                 <button type="button" role="tab" data-notes-tab="preview" aria-selected="false">Preview</button>
               </div>
             </div>
 
-            <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
-              <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
-              <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
-              <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
-              <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
-              <span class="notes-toolbar-sep" aria-hidden="true"></span>
-              <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-                <span id="notes-current-time-label">0:00</span>
-              </button>
-            </div>
-
-            <div class="notes-view" id="notes-edit-view">
-              <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
-            </div>
-
-            <div class="notes-view" id="notes-preview-view" hidden>
-              <div class="notes-preview-body" id="notes-preview-body">
-                <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+            <div class="notes-panel-body" id="notes-panel-body">
+              <div class="notes-toolbar" role="toolbar" aria-label="Note formatting" id="notes-toolbar">
+                <button type="button" class="notes-format-btn" data-note-format="h1" aria-label="Heading 1">H1</button>
+                <button type="button" class="notes-format-btn" data-note-format="h2" aria-label="Heading 2">H2</button>
+                <button type="button" class="notes-format-btn" data-note-format="h3" aria-label="Heading 3">H3</button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-format-btn" data-note-format="bold" aria-label="Bold"><strong>B</strong></button>
+                <button type="button" class="notes-format-btn" data-note-format="italic" aria-label="Italic"><em>I</em></button>
+                <span class="notes-toolbar-sep" aria-hidden="true"></span>
+                <button type="button" class="notes-timestamp-btn" id="notes-insert-timestamp" aria-label="Insert current video time">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                  <span id="notes-current-time-label">0:00</span>
+                </button>
               </div>
-            </div>
 
-            <div class="notes-footer">
-              <p class="notes-status" id="notes-status" role="status"></p>
-              <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              <div class="notes-view" id="notes-edit-view">
+                <textarea id="notes-textarea" class="notes-textarea" placeholder="Write notes as you watch. Try: 05:00 this part was **so powerful** because..." aria-label="Your notes for this episode" maxlength="20000"></textarea>
+              </div>
+
+              <div class="notes-view" id="notes-preview-view" hidden>
+                <div class="notes-preview-body" id="notes-preview-body">
+                  <p class="notes-empty">Nothing written yet. Switch to Edit to add notes.</p>
+                </div>
+              </div>
+
+              <div class="notes-footer">
+                <p class="notes-status" id="notes-status" role="status"></p>
+                <button type="button" class="notes-clear-btn" id="notes-clear-btn">Clear notes</button>
+              </div>
             </div>
           </section>
 
@@ -556,7 +564,7 @@
     <script src="./scripts/streak-ui.js?v=20260720-streak-label" defer></script>
     <script src="./scripts/popularity.js?v=20260711-popularity" defer></script>
     <script src="./scripts/related-videos.js?v=20260711-popularity" defer></script>
-    <script src="./scripts/watch-page.js?v=20260711-popularity" defer></script>
+    <script src="./scripts/watch-page.js?v=20260720-collapsible-notes" defer></script>
 
     <nav class="bottom-nav" aria-label="Main navigation">
       <a class="bottom-nav-item" href="./index.html">


### PR DESCRIPTION
## Summary

- remove the redundant “Standalone Video” line from homepage cards while retaining duration cues
- balance the anonymous Discover feed by alternating series and standalone lectures, reserving “For you” for genuinely personalized results
- fix mobile AI-search horizontal overflow and hide native topic scrollbars
- collapse empty notes on mobile while keeping saved notes expanded and readily editable
- keep episode filters on one swipeable row
- regenerate all canonical series and watch pages and add regression coverage

## Why

The soft-launch review found several places where mobile screen space was being spent on redundant metadata or expanded controls. It also uncovered a search-status nowrap rule that widened the page beyond the viewport. These changes improve first-impression content balance and keep the watch flow focused without changing the established visual language.

## Impact

Mobile visitors see denser cards, a more representative mix of series and videos, and quicker access to takeaways, recaps, and upcoming content. Desktop keeps the existing layout while receiving the balanced discovery order and compact standalone cards.

## Validation

- `npm run check`
- 22 Playwright smoke tests passed
- accessibility, JavaScript, content, taxonomy, generated-page, sitemap, and caption checks passed
- responsive browser verification at mobile and desktop sizes
